### PR TITLE
Russian translation + Removed language from URL for auto-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ User scripts put you in control of your  browsing experience. Once installed, th
     (Note, If you are using Tampermonkey extension in a Chrome-based browser, following [instructions](https://www.tampermonkey.net/faq.php#Q209) to enable Developer Mode.)
 
 2. Install this script by visiting Greasy Fork:
-    https://greasyfork.org/en/scripts/446342-telegram-media-downloader
+    https://greasyfork.org/scripts/446342-telegram-media-downloader
 
 ### Manual Installation
 1. install a user script manager

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ User scripts put you in control of your  browsing experience. Once installed, th
     To use user scripts you need to first install a user script manager. Which user script manager you can use depends on which browser you use.
 
     - Chrome: [Tampermonkey](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo) or [Violentmonkey](https://chrome.google.com/webstore/detail/violent-monkey/jinjaccalgkegednnccohejagnlnfdag)
-    - Firefox: [Greasemonkey](https://addons.mozilla.org/firefox/addon/greasemonkey/), [Tampermonkey](https://addons.mozilla.org/en-US/firefox/addon/tampermonkey/), or [Violentmonkey](https://addons.mozilla.org/en-US/firefox/addon/violentmonkey/)
+    - Firefox: [Greasemonkey](https://addons.mozilla.org/firefox/addon/greasemonkey/), [Tampermonkey](https://addons.mozilla.org/firefox/addon/tampermonkey/), or [Violentmonkey](https://addons.mozilla.org/firefox/addon/violentmonkey/)
     - Safari: [Tampermonkey](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo) or [Userscripts](https://apps.apple.com/app/userscripts/id1463298887)
     - Microsoft Edge: [Tampermonkey](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo) or [Violentmonkey](https://chrome.google.com/webstore/detail/violent-monkey/jinjaccalgkegednnccohejagnlnfdag)
     - Opera: [Tampermonkey](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo) or [Violentmonkey](https://chrome.google.com/webstore/detail/violent-monkey/jinjaccalgkegednnccohejagnlnfdag)

--- a/docs/greasyfork/ru-RU.md
+++ b/docs/greasyfork/ru-RU.md
@@ -1,0 +1,40 @@
+# Telegram: загрузчик медиафайлов
+
+**Раскройте Telegram: загружайте всё, что вам нравится.**
+
+Этот скрипт разблокирует и позволяет загружать изображения, GIF-файлы и видео в веб-приложениях Telegram из чатов, историй и даже частных каналов, где загрузка отключена или ограничена.
+
+Важно: этот скрипт **БЕСПЛАТНЫЙ** для использования. Если вы видите, что вас просят заплатить за скачивание, не платите и сообщите об этом в [GitHub Issue](https://github.com/Neet-Nestor/Telegram-Media-Downloader/issues) или в комментариях (рассматриваются сообщения преимущественно на английском языке), чтобы уведомить разработчика.
+
+## Как установить
+
+Установите расширение пользовательских скриптов и нажмите кнопку «Установить» выше, чтобы установить скрипт.
+
+**Важно:** если вы используете расширение Tampermonkey в браузере на базе Chrome, следуйте [инструкциям здесь](https://www.tampermonkey.net/faq.php#Q209), чтобы включить режим разработчика.
+
+
+## Как пользоваться
+Этот скрипт работает только в веб-приложении Telegram. Он добавляет кнопку скачивания для изображений, GIF и видео.
+
+![Скачивание изображения](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExY2VjNmU2ZDM0YTFlOWY4YTMzZDZmNjVlMDE2ODQ4OGY4N2E3MDFkNSZlcD12MV9pbnRlcm5hbF9naWZzX2dpZklkJmN0PWc/lqCVcw0pCd2VA3zqoE/giphy.gif)
+![Скачивание GIF](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExMzYwMzM3ZTMzYmI1MzA4M2EyYmY0NTFlOTg4OWFhNjhjNDk5YTkzYiZlcD12MV9pbnRlcm5hbF9naWZzX2dpZklkJmN0PWc/wnYzW4vwpPdeuo62nQ/giphy.gif)
+![Скачивание видео](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExMXcxYnJxaXMxcW05YW5rZ2YzZzE0bTU4aTBwYXI1N3pmdnVzbDFrdSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/EEPbblwmSpteAmwLls/giphy.gif)
+![Скачивание истории](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExZ3Z5Y2VzM2QzbW1xc3ZwNTQ2N3Q0a3lnanpxdW55c2Qzajl5NXZsaCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xJFjBGi8isHPR5cuHl/giphy.gif)
+
+Для видео в правом нижнем углу появится индикатор выполнения после начала загрузки. Для изображений и аудиозаписей индикатор выполнения не отображается.
+
+### Поддерживаемые версии веб-приложения
+Существует 2 различные версии веб-приложений Telegram:
+- https://webk.telegram.org / https://web.telegram.org/k/
+- https://webz.telegram.org / https://web.telegram.org/a/
+
+Этот скрипт должен работать на обеих версиях веб-приложений. Если вы используете другую версию и обнаружили, что этот скрипт не работает, пожалуйста, создайте проблему (Issue) в нашем [репозитории на GitHub](https://github.com/Neet-Nestor/Telegram-Media-Downloader/issues) (рассматриваются сообщения преимущественно на английском языке). 
+
+### Проверка хода загрузки
+Для видео в правом нижнем углу экрана будет отображаться индикатор выполнения. Вы также можете посмотреть журналы [консоли DevTools](https://developer.chrome.com/docs/devtools/open/).
+
+## Поддержать автора
+Если вам нравится этот скрипт, вы можете поддержать меня через [Venmo](https://venmo.com/u/NeetNestor) или [купить мне кофе](https://ko-fi.com/neetnestor) :)
+
+## Связаться
+Если у вас возникли проблемы с использованием этого скрипта, пожалуйста, обратитесь на наш [GitHub](https://github.com/Neet-Nestor/Telegram-Media-Downloader) и создайте проблему (Issue) (рассматриваются сообщения преимущественно на английском языке).

--- a/src/tel_download.js
+++ b/src/tel_download.js
@@ -1,9 +1,11 @@
 // ==UserScript==
 // @name         Telegram Media Downloader
+// @name:ru      Telegram: загрузчик медиафайлов
 // @name:zh-CN   Telegram图片视频下载器
 // @version      1.203
 // @namespace    https://github.com/Neet-Nestor/Telegram-Media-Downloader
 // @description  Download images, GIFs, videos, and voice messages on the Telegram webapp from private channels that disable downloading and restrict saving content
+// @description:ru Загружайте изображения, GIF-файлы, видео и голосовые сообщения в веб-приложении Telegram из частных каналов, которые отключили загрузку и ограничили сохранение контента
 // @description:zh-cn 从禁止下载的Telegram频道中下载图片、视频及语音消息
 // @author       Nestor Qin
 // @license      GNU GPLv3


### PR DESCRIPTION
Please remove ``en`` from repo website link so it will be fixed there too ``https://greasyfork.org/en/scripts/446342-telegram-media-downloader``.