### PR TITLE
Update icon codepoints

### DIFF
--- a/src/tel_download.js
+++ b/src/tel_download.js
@@ -28,8 +28,9 @@
     },
   };
   // Unicode values for icons (used in /k/ app)
-  const DOWNLOAD_ICON = "\uE94E";
-  const FORWARD_ICON = "\uE960";
+  // https://github.com/morethanwords/tweb/blob/master/src/icons.ts
+  const DOWNLOAD_ICON = "\uE95A";
+  const FORWARD_ICON = "\uE976";
   const contentRangeRegex = /^bytes (\d+)-(\d+)\/(\d+)$/;
   const REFRESH_DELAY = 500;
   const hashCode = (s) => {


### PR DESCRIPTION
Fixing https://github.com/Neet-Nestor/Telegram-Media-Downloader/issues/105

Seems like icon codepoints have changed, [actual ones available here](https://github.com/morethanwords/tweb/blob/master/src/icons.ts)

This PR updates codepoints for `DOWNLOAD` and `FORWARD` icons, which also fixes an issue of having duplicated `download` button (see issue screenshot)

After fix it look correct:
![Screenshot 2025-02-14 at 14 37 49](https://github.com/user-attachments/assets/b37849db-4617-4ff0-a2cb-aad881bb8396)

P.S> thanks for writing this extension
