### PR TITLE
Fix circle video download in K

### DIFF
--- a/src/tel_download.js
+++ b/src/tel_download.js
@@ -637,7 +637,7 @@
 
   // For webk /k/ webapp
   setInterval(() => {
-    /* Voice Message */
+    /* Voice Message or Circle Video */
     const pinnedAudio = document.body.querySelector(".pinned-audio");
     let dataMid;
     let downloadButtonPinnedAudio =
@@ -649,9 +649,9 @@
         "btn-icon tgico-download _tel_download_button_pinned_container";
       downloadButtonPinnedAudio.innerHTML = `<span class="tgico button-icon">${DOWNLOAD_ICON}</span>`;
     }
-    const voiceMessages = document.body.querySelectorAll("audio-element");
-    voiceMessages.forEach((voiceMessage) => {
-      const bubble = voiceMessage.closest(".bubble");
+    const audioElements = document.body.querySelectorAll("audio-element");
+    audioElements.forEach((audioElement) => {
+      const bubble = audioElement.closest(".bubble");
       if (
         !bubble ||
         bubble.querySelector("._tel_download_button_pinned_container")
@@ -661,15 +661,19 @@
       if (
         dataMid &&
         downloadButtonPinnedAudio.getAttribute("data-mid") !== dataMid &&
-        voiceMessage.getAttribute("data-mid") === dataMid
+        audioElement.getAttribute("data-mid") === dataMid
       ) {
         downloadButtonPinnedAudio.onclick = (e) => {
           e.stopPropagation();
-          tel_download_audio(link);
+          if (isAudio) {
+              tel_download_audio(link);
+          } else {
+              tel_download_video(link);
+          }
         };
         downloadButtonPinnedAudio.setAttribute("data-mid", dataMid);
-        const link =
-          voiceMessage.audio && voiceMessage.audio.getAttribute("src");
+        const link = audioElement.audio && audioElement.audio.getAttribute("src");
+        const isAudio = audioElement.audio && audioElement.audio instanceof HTMLAudioElement
         if (link) {
           pinnedAudio
             .querySelector(".pinned-container-wrapper-utils")


### PR DESCRIPTION
Fixes https://github.com/Neet-Nestor/Telegram-Media-Downloader/issues/108

`<audio-element>`'s `audio` property can store any kind of media, and in case of circle video, it is `<video>` type, so its `src` is a link to an actual video file, which we can then download.

_NB_: I haven't found neither voice message nor circle video download in A version
